### PR TITLE
Support object equivalents of primitives

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ types.null = function(name) {
 }
 
 types.boolean = function(name) {
-  return 'typeof '+name+' === "boolean"'
+  return name+' === true || '+name+' === false || ' +
+    name+' && typeof '+name+' === "object" && ' +
+    'Object.prototype.toString.call('+name+') === "[object Boolean]" || false'
 }
 
 types.array = function(name) {
@@ -55,7 +57,9 @@ types.object = function(name) {
 }
 
 types.number = function(name) {
-  return 'typeof '+name+' === "number"'
+  return 'typeof '+name+' === "number" || ' +
+    name+' && typeof '+name+' === "object" && ' +
+    'Object.prototype.toString.call('+name+') === "[object Number]" || false'
 }
 
 types.integer = function(name) {
@@ -63,7 +67,9 @@ types.integer = function(name) {
 }
 
 types.string = function(name) {
-  return 'typeof '+name+' === "string"'
+  return 'typeof '+name+' === "string" || ' +
+    name+' && typeof '+name+' === "object" && ' +
+    'Object.prototype.toString.call('+name+') === "[object String]" || false'
 }
 
 var unique = function(array) {

--- a/test/misc.js
+++ b/test/misc.js
@@ -186,3 +186,26 @@ tape('do not mutate schema', function(t) {
   t.same(sch, copy, 'did not mutate')
   t.end()
 })
+
+tape('primitives', function(t) {
+  var schema = {
+    type: 'object',
+    properties: {
+      foo: {type:'string'},
+      bar: {type:'number'},
+      baz: {type:'boolean'}
+    }
+  }
+
+  var validate = validator(schema)
+
+  t.ok(validate({foo: new String('world')}), 'should be valid')
+  t.ok(validate({foo: new Object('world')}), 'should be valid')
+  t.ok(validate({bar: new Number(0)}), 'should be valid')
+  t.ok(validate({bar: new Object(0)}), 'should be valid')
+  t.ok(validate({baz: new Boolean(true)}), 'should be valid')
+  t.ok(validate({baz: new Boolean(false)}), 'should be valid')
+  t.ok(validate({baz: new Object(true)}), 'should be valid')
+  t.ok(validate({baz: new Object(false)}), 'should be valid')
+  t.end()
+})


### PR DESCRIPTION
This patch fixes the type checks for strings, numbers, and booleans so that the object equivalents of these primitives are recognized. Without this patch, values like `new String('world')`, `new Number(0)`, and `new Boolean(false)`, were not being recognized as strings, numbers, and booleans.