### PR TITLE
Fix enum error message

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -113,7 +113,7 @@ var compile = function(sch) {
         }
 
         validate('if (%s) {', node.values.map(toCompare).join(' && ') || 'true')
-        error('must be one of ['+enm.join(', ')+']')
+        error('must be one of ['+node.values.join(', ')+']')
         validate('}')
         return
       }

--- a/test/validate.js
+++ b/test/validate.js
@@ -94,3 +94,21 @@ tape('nested array', function(t) {
   t.notOk(validate({list:[1]}))
   t.end()
 })
+
+tape('enum', function(t) {
+  var validate = validator({
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'number',
+        required: true,
+        enum: [42]
+      }
+    }
+  })
+
+  t.notOk(validate({}), 'is required')
+  t.ok(validate({foo:42}))
+  t.notOk(validate({foo:43}))
+  t.end()
+})


### PR DESCRIPTION
If using `enum` in your schema and you had some JSON that didn't validate with the enum requirements, it would throw the following error when it tried to generate the error message:

```
ReferenceError: enm is not defined
```
