### PR TITLE
stop crash on array defs without items property

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -54,7 +54,7 @@ module.exports = function(schema) {
         break
 
         case 'array':
-        root.items = visit({}, node.items)
+        root.items = visit({}, node.items || {})
         root.conditions++
         break
       }


### PR DESCRIPTION
Section 5.3 in the specification for arrays keyword says that if items
property is not present it should be considered present with an empty schema.
Update the normalise code to handle this assumption, allowing the parsing
of the Json-schema draft 4 meta schema.

I'm trying to use the meta schema to validate other schemas as well as using schemas to validate normal json so I need to be able to compile the meta schema from http://json-schema.org/documentation.html.  Not sure if this was the best way to do it but it seemed to work.