### PR TITLE
Support for filtering away additional properties not in schema. Fixes #17 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ validate('hello') // returns true
 validate(42) // return false
 ```
 
+## Filtering away additional properties
+is-my-json-valid supports filtering away properties not in the schema
+``` js
+var filter = validator({
+  required: true,
+  type: 'object',
+  properties: {
+    hello: {type: 'string', required: true}
+  },
+  additionalProperties: false
+}, {
+  filter: true
+})
+
+var doc = {hello: 'world', notInSchema: true}
+
+console.log(filter(doc)) // false
+console.log(doc) // {hello: 'world'}
+```
+
 ## Performance
 
 is-my-json-valid uses code generation to turn your JSON schema into basic javascript code that is easily optimizeable by v8.


### PR DESCRIPTION
Not you have to pass the `{filter:true}`to bothe the schema compiler and the validator.

I chose to pass it to the compiler to, have no impact on the normal use case where you are not using the filter option

The solution ended up not having much of an impact on the normal use case, so let me know if I should remove the need for passing `{filter:true}` to the schema compiler.