### PR TITLE
Improve formatName

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ var get = function(obj, additionalSchemas, ptr) {
 }
 
 var formatName = function(field) {
-  return field.replace(/\[[^\]]+\]/g, '.*')
+  var pattern = /\[[^\[\]"]+\]/;
+  while(pattern.test(field)){
+    field = field.replace(pattern, '.*');
+  }
+  return field
 }
 
 var types = {}


### PR DESCRIPTION
To avoid data.*] and to show full name for data["some key with space"], closing #23 #21