### PR TITLE
Allow to pass opts when using the require-loader

### DIFF
--- a/require.js
+++ b/require.js
@@ -4,9 +4,9 @@ var compile = require('./')
 
 delete require.cache[require.resolve(__filename)]
 
-module.exports = function(file, encodings) {
+module.exports = function(file, opts) {
   file = path.join(path.dirname(module.parent.filename), file)
   if (!fs.existsSync(file) && fs.existsSync(file+'.schema')) file += '.schema'
   if (!fs.existsSync(file) && fs.existsSync(file+'.json')) file += '.json'
-  return compile(fs.readFileSync(file, 'utf-8'))
+  return compile(fs.readFileSync(file, 'utf-8'), opts)
 }


### PR DESCRIPTION
The same way as when creating from a schema object. Remove encodings argument, as it is not used.

Any comments, @mafintosh ?