### PR TITLE
Allow format functions to provide error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,17 @@ var compile = function(schema, cache, root, reporter, opts) {
         }
       }
     }
+    var errorFromSym = function(sym) {
+      validate('errors++')
+      if (reporter === true) {
+        validate('if (validate.errors === null) validate.errors = []')
+        if (verbose) {
+          validate('validate.errors.push({field:%s,message:%s,value:%s})', JSON.stringify(formatName(name)), sym, name)
+        } else {
+          validate('validate.errors.push({field:%s,message:%s})', JSON.stringify(formatName(name)), sym)
+        }
+      }
+    }
 
     if (node.required === true) {
       indent++
@@ -182,10 +193,19 @@ var compile = function(schema, cache, root, reporter, opts) {
       var n = gensym('format')
       scope[n] = fmts[node.format]
 
-      if (typeof scope[n] === 'function') validate('if (!%s(%s)) {', n, name)
-      else validate('if (!%s.test(%s)) {', n, name)
-      error('must be '+node.format+' format')
-      validate('}')
+      if (typeof scope[n] === 'function') {
+        var r = gensym('result')
+        validate('%s = %s(%s)', r, n, name)
+        validate('if (!%s) {', r)
+        error('must be '+node.format+' format')
+        validate('} else if (%s instanceof Error) {', r)
+        errorFromSym(n + '.message')
+        validate('}')
+      } else {
+        validate('if (!%s.test(%s)) {', n, name)
+        error('must be '+node.format+' format')
+        validate('}')
+      }
       if (type !== 'string' && formats[node.format]) validate('}')
     }
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -231,6 +231,31 @@ tape('custom format function', function(t) {
   t.end()
 })
 
+tape('custom format function with custom error reporting', function(t) {
+  var validate = validator({
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        format: 'as'
+      }
+    }
+  }, {
+    formats: {
+      as:function(s) {
+        if (s !== 'as') {
+          return new Error('should be "as"')
+        }
+        return true;
+      }
+    }
+  })
+
+  t.notOk(validate({foo:''}), 'should be "as"')
+  t.ok(validate({foo:'as'}), 'as')
+  t.end()
+})
+
 tape('do not mutate schema', function(t) {
   var sch = {
     items: [


### PR DESCRIPTION
If format function returns an error then it's treated as failure by validator
and it's `message` attribute is used as error message.

Fixes #43