### PR TITLE
Include ref schema errors inline

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ var compile = function(schema, cache, root, reporter, opts) {
         validate('for (var %s = %d; %s < %s.length; %s++) {', i, node.items.length, i, name, i)
         visit(name+'['+i+']', node.additionalItems, reporter, filter)
         validate('}')
-      }   
+      }
     }
 
     if (node.format && fmts[node.format]) {
@@ -307,12 +307,21 @@ var compile = function(schema, cache, root, reporter, opts) {
           cache[node.$ref] = function proxy(data) {
             return fn(data)
           }
-          fn = compile(sub, cache, root, false, opts)
+          fn = compile(sub, cache, root, true, opts)
         }
         var n = gensym('ref')
         scope[n] = fn
         validate('if (!(%s(%s))) {', n, name)
-        error('referenced schema does not match')
+        if (reporter === true) {
+          validate('if (validate.errors === null) validate.errors = []')
+        }
+        validate('%s.errors.forEach(function(e) {', n)
+        validate('errors++')
+        if (reporter === true) {
+          validate('e.field = %j + e.field.substr(4)', formatName(name))
+          validate('validate.errors.push(e)')
+        }
+        validate('})')
         validate('}')
       }
     }
@@ -379,7 +388,7 @@ var compile = function(schema, cache, root, reporter, opts) {
       node.anyOf.forEach(function(sch, i) {
         if (i === 0) {
           validate('var %s = errors', prev)
-        } else {          
+        } else {
           validate('if (errors !== %s) {', prev)
             ('errors = %s', prev)
         }
@@ -430,7 +439,7 @@ var compile = function(schema, cache, root, reporter, opts) {
 
     if (node.maxProperties !== undefined) {
       if (type !== 'object') validate('if (%s) {', types.object(name))
-      
+
       validate('if (Object.keys(%s).length > %d) {', name, node.maxProperties)
       error('has more properties than allowed')
       validate('}')
@@ -440,7 +449,7 @@ var compile = function(schema, cache, root, reporter, opts) {
 
     if (node.minProperties !== undefined) {
       if (type !== 'object') validate('if (%s) {', types.object(name))
-      
+
       validate('if (Object.keys(%s).length < %d) {', name, node.minProperties)
       error('has less properties than allowed')
       validate('}')
@@ -450,7 +459,7 @@ var compile = function(schema, cache, root, reporter, opts) {
 
     if (node.maxItems !== undefined) {
       if (type !== 'array') validate('if (%s) {', types.array(name))
-      
+
       validate('if (%s.length > %d) {', name, node.maxItems)
       error('has more items than allowed')
       validate('}')
@@ -460,7 +469,7 @@ var compile = function(schema, cache, root, reporter, opts) {
 
     if (node.minItems !== undefined) {
       if (type !== 'array') validate('if (%s) {', types.array(name))
-      
+
       validate('if (%s.length < %d) {', name, node.minItems)
       error('has less items than allowed')
       validate('}')

--- a/test/misc.js
+++ b/test/misc.js
@@ -278,6 +278,38 @@ tape('external schemas', function(t) {
   t.end()
 })
 
+tape('external schema nested errors', function(t) {
+  var schemas = {
+    outer: {
+      type: 'object',
+      properties: {
+        foo: {
+          '$ref': '#inner'
+        }
+      }
+    },
+    inner: {
+      type: 'object',
+      properties: {
+        bar: {
+          type: 'string',
+        },
+        zim: {
+          type: 'number'
+        }
+      }
+    },
+  }
+
+  var validate = validator(schemas.outer, {schemas: schemas})
+
+  t.notOk(validate({foo: {bar: 42, zim: 'abc'}}), 'invalid')
+  t.equal(validate.errors.length, 2, 'two nested errors')
+  t.equal(validate.errors[0].field, 'data.foo.bar', 'errors should nest')
+  t.equal(validate.errors[1].field, 'data.foo.zim', 'errors should nest')
+  t.end()
+})
+
 tape('nested required array decl', function(t) {
   var schema = {
     properties: {


### PR DESCRIPTION
Here is one way that you could deal with errors from referenced schemas. This implementation includes all errors from referenced schemas inline with the top-level schema's errors. It does have to do some clunky string manipulation on nested error field names, but the final effect is nice.

I also have to compile referenced schemas with the reporter flag set to true which actually obviates the flag completely. If you like this approach, you may want to drop the reporter flag and associated logic.