### PR TITLE
Removed junk character after "|| " on lines 135 and 138

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,10 +132,10 @@ var compile = function(schema, cache, root, reporter, opts) {
       if (reporter === true) {
         validate('if (validate.errors === null) validate.errors = []')
         if (verbose) {
-          validate('validate.errors.push({field:%s,message:%s,value:%s})', JSON.stringify(formatName(prop || name)), JSON.stringify(msg), value || name)
+          validate('validate.errors.push({field:%s,message:%s,value:%s})', JSON.stringify(formatName(prop || name)), JSON.stringify(msg), value || name)
         } else {
           var n = gensym('error')
-          scope[n] = {field:formatName(prop || name), message:msg}
+          scope[n] = {field:formatName(prop || name), message:msg}
           validate('validate.errors.push(%s)', n)
         }
       }


### PR DESCRIPTION
Junk character **Â** causes issues when running tests with Jasmine.

*Uncaught SyntaxError: Unexpected identifier:*
<pre><code>
    ...
    var error = function(msg, prop, value) {
      validate('errors++')
      if (reporter === true) {
        validate('if (validate.errors === null) validate.errors = []')
        if (verbose) {
          validate('validate.errors.push({field:%s,message:%s,value:%s})', JSON.stringify(formatName(prop || name)), JSON.stringify(msg), value ||Â name)
        } else {
          var n = gensym('error')
          scope[n] = {field:formatName(prop ||Â name), message:msg}
          validate('validate.errors.push(%s)', n)
        }
      }
    }
</code></pre>
