### PR TITLE
Minor tweaks regarding `required: true` (encourage v4-style `required`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ Simply pass a schema to compile it
 var validator = require('is-my-json-valid')
 
 var validate = validator({
-  required: true,
   type: 'object',
   properties: {
     hello: {
-      required: true,
       type: 'string'
     }
-  }
+  },
+  required: ['hello']
 })
 
 console.log('should be valid', validate({hello: 'world'}))
@@ -58,7 +57,6 @@ If you want to add your own custom formats pass them as the formats options to t
 ``` js
 var validate = validator({
   type: 'string',
-  required: true,
   format: 'only-a'
 }, {
   formats: {
@@ -76,7 +74,6 @@ You can pass in external schemas that you reference using the `$ref` attribute a
 
 ``` js
 var ext = {
-  required: true,
   type: 'string'
 }
 
@@ -97,11 +94,11 @@ is-my-json-valid supports filtering away properties not in the schema
 
 ``` js
 var filter = validator.filter({
-  required: true,
   type: 'object',
   properties: {
-    hello: {type: 'string', required: true}
+    hello: {type: 'string'}
   },
+  required: ['hello'],
   additionalProperties: false
 })
 
@@ -115,14 +112,13 @@ is-my-json-valid outputs the value causing an error when verbose is set to true
 
 ``` js
 var validate = validator({
-  required: true,
   type: 'object',
   properties: {
     hello: {
-      required: true,
       type: 'string'
     }
-  }
+  },
+  required: ['hello']
 }, {
   verbose: true
 })

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ var compile = function(schema, cache, root, reporter, opts) {
       }
     }
 
-    if (node.required === true) {
+    if (node.required === true && opts.requiredV3 === true) {
       indent++
       validate('if (%s === undefined) {', name)
       error('is required')
@@ -511,6 +511,9 @@ var compile = function(schema, cache, root, reporter, opts) {
 
   var validate = genfun
     ('function validate(data) {')
+      ('if (data === undefined) {')
+        ('throw new Error("`undefined` is not a valid JSON value");')
+      ('}')
       ('validate.errors = null')
       ('var errors = 0')
 
@@ -541,7 +544,7 @@ var compile = function(schema, cache, root, reporter, opts) {
 
 module.exports = function(schema, opts) {
   if (typeof schema === 'string') schema = JSON.parse(schema)
-  return compile(schema, {}, schema, true, opts)
+  return compile(schema, {}, schema, true, xtend({requiredV3: true}, opts))
 }
 
 module.exports.filter = function(schema, opts) {

--- a/test/misc.js
+++ b/test/misc.js
@@ -15,7 +15,7 @@ tape('simple', function(t) {
   var validate = validator(schema)
 
   t.ok(validate({hello: 'world'}), 'should be valid')
-  t.notOk(validate(), 'should be invalid')
+  t.notOk(validate(null), 'should be invalid')
   t.notOk(validate({}), 'should be invalid')
   t.end()
 })
@@ -111,7 +111,7 @@ tape('array', function(t) {
   })
 
   t.notOk(validate({}), 'wrong type')
-  t.notOk(validate(), 'is required')
+  t.notOk(validate(null), 'is required')
   t.ok(validate(['test']))
   t.end()
 })
@@ -362,5 +362,43 @@ tape('Date.now() is an integer', function(t) {
   var validate = validator(schema)
 
   t.ok(validate(Date.now()), 'is integer')
+  t.end()
+})
+
+tape('undefined is invalid input', function(t) {
+  var schema = {type: 'array'}
+  var validate = validator(schema)
+  t.throws(function() {
+    validate(undefined)
+  }, 'undefined is not valid JSON')
+  t.end()
+})
+
+tape('disable v3-style required', function(t) {
+  var schema = {
+    type: 'object',
+    properties: {
+      prop: {
+        type: 'string',
+        required: true
+      }
+    }
+  };
+  var validateV4 = validator(schema, {
+    requiredV3: false
+  });
+  var validateV3 = validator(schema, {
+    requiredV3: true
+  });
+  var validate = validator(schema);
+  // Sanity check that both can validate with the property
+  t.ok(validateV4({prop: 'a string'}), 'should validate with prop');
+  t.ok(validateV3({prop: 'a string'}), 'should validate with prop');
+  // Check that requiredV3: false causes `required: true` to be ignored
+  t.ok(validateV4({}), 'v4 should validate without prop');
+  t.notOk(validateV3({}), 'v3 should not validate without prop');
+  // Check that `requiredV3: true` is default
+  t.ok(validate({prop: 'a string'}), 'should validate with prop');
+  t.notOk(validate({}), 'v3 should not validate without prop');
   t.end()
 })


### PR DESCRIPTION
  * Remove usage from example in `README.md`, encourage v4-style `required: ['prop', ...]` instead.
  * Throw error if `undefined` is given as input (it's invalid JSON, hence, invalid input).
  * Support for disabling v3-style `required: true`.

---
I've added the option `requiredV3` which defaults to `true`, to preserve backward compatibility.
It's probably best to disable by default, because it's an implementation specific feature, like `filter`.
(Note, there might be a better name for the option than `requiredV3`, suggestions are welcome).

Long-term this is probably something that should be disabled by default, you can probably roll that out with a major version upgrade.

---
**Breaking change**, some of the test cases used `undefined` as input. This is not a valid JSON value, so it's IMO acceptable that `is-my-json-valid` exhibits undefined-behaviour. I would surely expect weird things to happen if I tried to run validate on a `Buffer` object or some other non-JSON value :)

The reason I'm phrasing like this is that, before code like:
```js
validate = validator({type: 'array'});
validate(undefined); // No error before
```
Would not return a validation error. But if the schema had been `{type: 'array', required: true}` it would have returned an error. `required: true` is not valid v4 JSON schema, and should not be necessary, however, strictly speaking there is nothing wrong with this behaviour because `undefined` is invalid input -- so undefined/implementation-specific behavior is fine :)

Implementation-specific behaviour is, however, a dangerous footgun. Powerful, but best hidden behind option flags, like `filter`.

I suggest we throw a runtime error. I don't think we should return a validation error, because `undefined` is not a JSON value, hence, it's an input error, not a validation error (similar to someone providing a `Buffer` object as input). It's probably not necessary to guard against all possible input errors, like circular object references etc. but `undefined` is probably a common input error that people easily end up relying on.