### PR TITLE
Expose errors from `filter` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,28 @@ validate(42) // return false
 
 ## Filtering away additional properties
 
-is-my-json-valid supports filtering away properties not in the schema
+is-my-json-valid supports filtering away properties not in the schema.
+The option `filter` changes the semantics of the `additionalProperties: false`,
+such that additional properties are deleted instead of causing a validation
+error. Be warned this is a non-standard feature, and it will mutate the input
+object.
 
 ``` js
-var filter = validator.filter({
-  required: true,
+var schema = {
   type: 'object',
   properties: {
-    hello: {type: 'string', required: true}
+    hello: {type: 'string'}
   },
   additionalProperties: false
-})
+};
+
+var validateAndfilter = validator(schema, {
+  filter: true
+});
 
 var doc = {hello: 'world', notInSchema: true}
-console.log(filter(doc)) // {hello: 'world'}
+console.log(validateAndfilter(doc)) // true (ie. no error)
+console.log(doc) // {hello: 'world'}
 ```
 
 ## Verbose mode outputs the value on errors

--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ var compile = function(schema, cache, root, reporter, opts) {
     return v
   }
 
+  var validate;
   var visit = function(name, node, reporter, filter) {
     var properties = node.properties
     var type = node.type
@@ -509,7 +510,7 @@ var compile = function(schema, cache, root, reporter, opts) {
     while (indent--) validate('}')
   }
 
-  var validate = genfun
+  validate = genfun
     ('function validate(data) {')
       ('validate.errors = null')
       ('var errors = 0')

--- a/index.js
+++ b/index.js
@@ -287,8 +287,12 @@ var compile = function(schema, cache, root, reporter, opts) {
           ('if (%s) {', additionalProp)
 
       if (node.additionalProperties === false) {
-        if (filter) validate('delete %s', name+'['+keys+'['+i+']]')
-        error('has additional properties', null, JSON.stringify(name+'.') + ' + ' + keys + '['+i+']')
+        if (filter) {
+          validate('delete %s', name+'['+keys+'['+i+']]')
+        } else {
+          error('has additional properties', null,
+                JSON.stringify(name+'.') + ' + ' + keys + '['+i+']')
+        }
       } else {
         visit(name+'['+keys+'['+i+']]', node.additionalProperties, reporter, filter)
       }
@@ -543,12 +547,4 @@ var compile = function(schema, cache, root, reporter, opts) {
 module.exports = function(schema, opts) {
   if (typeof schema === 'string') schema = JSON.parse(schema)
   return compile(schema, {}, schema, true, opts)
-}
-
-module.exports.filter = function(schema, opts) {
-  var validate = module.exports(schema, xtend(opts, {filter: true}))
-  return function(sch) {
-    validate(sch)
-    return sch
-  }
 }

--- a/test/filter_test.js
+++ b/test/filter_test.js
@@ -1,0 +1,51 @@
+var tape = require('tape');
+var validator = require('../');
+
+tape('filter with {additionalProperties: false}', function(t) {
+  t.plan(2);
+
+  var schema = {
+    type: 'object',
+    properties: {
+      prop: {type:  'string'}
+    },
+    additionalProperties: false
+  };
+
+  var validate = validator(schema, {
+    filter:     true
+  });
+
+  var value = {
+    prop:   'my-value',
+    extra:  'should be filtered out'
+  };
+
+  t.ok(validate(value), 'should be valid, as we have {filter: true}');
+  t.deepEqual(value, {prop: 'my-value'}, 'should filter properties');
+});
+
+tape('{filter: true} still produces errors', function(t) {
+  t.plan(2);
+
+  var schema = {
+    type: 'object',
+    properties: {
+      prop: {type:  'string'}
+    },
+    required: ['prop'],
+    additionalProperties: false
+  };
+
+  var validate = validator(schema, {
+    filter:     true
+  });
+
+  var value = {
+    extra:  'should be filtered out'
+  };
+
+  t.notOk(validate(value), 'should not be valid');
+  t.ok(validate.errors instanceof Array &&
+       validate.errors.length > 0, 'should have errors');
+});


### PR DESCRIPTION
  * Make errors available when using the `filter` feature
  * Ignore errors from `additionalProperties: false`
  * Formalize semantics in `README.md`
  * Warn about input mutation.
  * Warn that this is a non-standard feature.
  * Added test cases covering the `filter` feature

---
This is clearly an implementation-specific feature. I'll admit I thought it was a bit weird when I first saw the feature... But I now realize that is has some use-cases, and, hence, think that issue #44 deserves a bit of attention.

---
**Interface change**, before the feature was available both using the option flag `filter: true` and using `validator.filter`. As the `validator.filter` interface doesn't expose errors I think it makes most sense to restrict to the option flag method (it seems like a good way to provide various implementation-specific options).

---
**Formal semantics**, I changed the implementation to ignore errors from `additionalProperties: false` when `filter: true`... But still produce all the other errors. I'm not what semantics are best for this feature, but it seems reasonably sane to say that idea to change the semantics of `additionalProperties: false` from producing validation errors, to instead deleting additional properties.

This way the validation errors produced are still well-defined, all we have a clear change in semantics for objects with `additionalProperties: false`.