### PR TITLE
Accept top-level schema and resolve referenced sub-schema paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,24 @@ var get = function(obj, additionalSchemas, ptr) {
   try {
     return jsonpointer.get(obj, decodeURI(ptr))
   } catch (err) {
-    var other = additionalSchemas[ptr] || additionalSchemas[ptr.replace(/^#/, '')]
+    var end = ptr.indexOf('#')
+    var other
+    // external reference
+    if (end !== 0) {
+      // fragment doesn't exist.
+      if (end === -1) {
+        other = additionalSchemas[ptr]
+      } else {
+        var ext = ptr.slice(0, end)
+        other = additionalSchemas[ext]
+        var fragment = ptr.slice(end).replace(/^#/, '')
+        try {
+          return jsonpointer.get(other, fragment)
+        } catch (err) {}
+      }
+    } else {
+      other = additionalSchemas[ptr]
+    }
     return other || null
   }
 }

--- a/test/misc.js
+++ b/test/misc.js
@@ -304,6 +304,7 @@ tape('top-level external schema', function(t) {
   })
   t.ok(validate({name:"alice", sex:"female"}), 'is an object')
   t.notOk(validate({name:"alice", sex: "bob"}), 'recognizes external schema')
+  t.notOk(validate({name:2, sex: "female"}), 'recognizes external schema')
   t.end()
 })
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -278,6 +278,35 @@ tape('external schemas', function(t) {
   t.end()
 })
 
+tape('top-level external schema', function(t) {
+  var defs = {
+    "string": {
+      type: "string"
+    },
+    "sex": {
+      type: "string",
+      enum: ["male", "female", "other"]
+    }
+  }
+  var schema = {
+    type: "object",
+    properties: {
+      "name": { $ref: "definitions.json#/string" },
+      "sex": { $ref: "definitions.json#/sex" }
+    },
+    required: ["name", "sex"]
+  }
+
+  var validate = validator(schema, {
+    schemas: {
+      "definitions.json": defs
+    }
+  })
+  t.ok(validate({name:"alice", sex:"female"}), 'is an object')
+  t.notOk(validate({name:"alice", sex: "bob"}), 'recognizes external schema')
+  t.end()
+})
+
 tape('nested required array decl', function(t) {
   var schema = {
     properties: {


### PR DESCRIPTION
While it is currently possible to reference external schemas provided up-front, it is required that each sub-schema path referenced in the main schema is enumerated. This would be the format of the relevant test code without this change:

```javascript
var defs = {
  "string": {
    type: "string"
  },
  "sex": {
    type: "string",
    enum: ["male", "female", "other"]
  }
}

var schema = {
  type: "object",
  properties: {
    "name": { $ref: "definitions.json#/string" },
    "sex": { $ref: "definitions.json#/sex" }
  },
  required: ["name", "sex"]
}

var validate = validator(schema, {
  schemas: {
    "definitions.json#/string": defs.string,
    "definitions.json#/sex": defs.sex
  }
})
```

This change adds the capability for an external schema to be provided once and JSON pointers into the external reference are resolved during compilation. The test code is copied here for reference:

```javascript
var defs = {
  "string": {
    type: "string"
  },
  "sex": {
    type: "string",
    enum: ["male", "female", "other"]
  }
}

var schema = {
  type: "object",
  properties: {
    "name": { $ref: "definitions.json#/string" },
    "sex": { $ref: "definitions.json#/sex" }
  },
  required: ["name", "sex"]
}

var validate = validator(schema, {
  schemas: {
    "definitions.json": defs
  }
})
```

This was one piece of functionality mentioned that would satisfy #66, and also helps resolve some issues I have using this library in my own project.