### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ var schema = {
 }
 
 // pass the external schemas as an option
-var validate = validate(schema, {schemas: {ext: ext}})
+var validate = validator(schema, {schemas: {ext: ext}})
 
 validate('hello') // returns true
 validate(42) // return false


### PR DESCRIPTION
hey, sweet module. :smile:

this fixes a very minor typo in the README: line 88 should say `validator` instead of `validate` in order to be consistent with the rest of the docs.

cheers! :tea: 