### PR TITLE
Use Object.defineProperty instead of __defineGetter__

### DIFF
--- a/index.js
+++ b/index.js
@@ -543,13 +543,15 @@ var compile = function(schema, cache, root, reporter, opts) {
   validate = validate.toFunction(scope)
   validate.errors = null
 
-  validate.__defineGetter__('error', function() {
-    if (!validate.errors) return ''
-    return validate.errors
-      .map(function(err) {
-        return err.field+' '+err.message
-      })
-      .join('\n')
+  Object.defineProperty(validate, 'error', {
+    get: function() {
+      if (!validate.errors) return ''
+      return validate.errors
+        .map(function(err) {
+          return err.field+' '+err.message
+        })
+        .join('\n')
+    }
   })
 
   validate.toJSON = function() {


### PR DESCRIPTION
`__defineGetter__` is non-standard and doesn't exist in IE<=10