### PR TITLE
Expose the types collection to allow custom schema types and coercers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -573,3 +573,4 @@ module.exports.filter = function(schema, opts) {
     return sch
   }
 }
+module.exports.types=types;


### PR DESCRIPTION
Being able to tie in custom property types and coercers would be valuable addition to this project, especially if it could be easily done without increasing the scope of this project. Luckily, it can be done by adding a single line that exposes the types collection.

By simply exposing the types collection, custom types and coercers can be created by users.

A prime example is validating objects for use in MongoDB queries: the _id properties must be of Mongo's ObjectID type.

The schema, which already has all information on complex object properties, could support the ObjectID type, casting the string representation to the proper object automatically.

The following is a comment from this enhancement request:
https://github.com/mafintosh/is-my-json-valid/issues/34

I was able to accomplish this by adding a single line to the validator code.

At the bottom of **`is-my-json-valid/index.js`** add the following line:
`module.exports.types=types;`

The world is now your oyster! You can create custom types and coercers.

To manage the MongoDB's **`_id`** field, add the following to your project code:
```
// Step 1: Make Mongo's ObjectId class global.
GLOBAL.ObjectId = require('mongodb').ObjectID;

// Step 2: Include is-my-json-valid.
var jsonValidatorFactory = require('is-my-json-valid');

// Step 3: Create a validator for a custom type called ObjectId that also coerces.
// It must do this inside of an if statement, using a conditional operator.
// The logic is as follows:
//    Is the value a string of 24 hex characters?
//       YES: Change the property to an ObjectId and return it (truthy).
//       NO: Is the value a non-null object whos constructor is ObjectId?
//          YES: Return true.
//          NO: Return false.
jsonValidatorFactory.types.ObjectId = function(name) {
   return 'typeof '+name+' === "string" && /^[0-9a-f]{24}$/i.test('+name+') ? '+name+'=ObjectId('+name+') : '+name+' && '+name+'.constructor===ObjectId';
};
```
That is it! In the schema, you can use the type **`ObjectId`**, like so:
```
// Create a schema, using the new ObjectId type for the _id property.
var mySchema={
   required : true,
   type : "object",
   properties : {
      _id : {
         required : true,
         type : "ObjectId"
      }
   },
   additionalProperties : false
};

// Create a validator for the schema.
var myValidator=jsonValidatorFactory(mySchema);

// Create some test data with _id as a string.
var myData={ _id : "56b98ca35c55e4a8061a92d8" };
console.log("[START]  typeof _id:"+typeof(myData._id)+"   value:"+myData._id);

// Now call the validator with test data.
var isValid=myValidator(myData);
console.log("[FIRST] isValid:"+isValid+"  typeof _id:"+typeof(myData._id)+"   value:"+myData._id);
// isValid is true, and myData._id is now of type ObjectId! Woot!

// Test the validation against the data in its new form as well.
var isAlsoValid=myValidator(myData);
console.log("[SECOND] isValid:"+isValid+"  typeof _id:"+typeof(myData._id)+"   value:"+myData._id);
// isAlsoValid is also true!

// Try a bad _id string.
myData._id="56b9"; // Too short!
var isValid=myValidator(myData);
console.log("[THIRD] isValid:"+isValid+"  typeof _id:"+typeof(myData._id)+"   value:"+myData._id);
// isValid is false, and myData._id is still the unchanged string.
```
The console will show:
```
[START]  typeof _id:string   value:56b98ca35c55e4a8061a92d8
[FIRST] isValid:true  typeof _id:object   value:56b98ca35c55e4a8061a92d8
[SECOND] isValid:true  typeof _id:object   value:56b98ca35c55e4a8061a92d8
[THIRD] isValid:false  typeof _id:string   value:56b9
```
I will submit a pull request for the one line.