### PR TITLE
Fixed multipleOf returns error because of wrong floating point precision

### DIFF
--- a/test/json-schema-draft4/multipleOf.json
+++ b/test/json-schema-draft4/multipleOf.json
@@ -56,5 +56,41 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by decimal number where floating point precision is wrong",
+        "schema": {"multipleOf": 0.01},
+        "tests": [
+            {
+                "description": "Number 2 is multiple of 0.01",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "Number 2.1 is multiple of 0.01",
+                "data": 2.1,
+                "valid": true
+            },
+            {
+                "description": "Number 2.2 is multiple of 0.01",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "Number 2.3 is multiple of 0.01",
+                "data": 2.3,
+                "valid": true
+            },
+            {
+                "description": "Number 2.4 is multiple of 0.01",
+                "data": 2.4,
+                "valid": true
+            },
+            {
+                "description": "Number 1.211 is not multiple of 0.01",
+                "data": 1.211,
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
There is a bug when checking the `multipleOf` attribute that happens when the calculations have wrong floating point precision.
For example testing `2.2` against `multipleOf: 0.01` returns error, because in javascript `100 * 2.2` (where 100 is `factor`) returns `220.00000000000003` and not `200`.

The fix is to round the calculation only when we are sure the result should be an integer (when the number to test has the same amount of or less decimals than multipleOf), and because this would break the other case (the number to test has more decimals than multipleOf) we just return that the validation has failed since it's clearly not its multiple.

I have added tests for cases when this happens for both rounding `100 * 2.2 = 220.00000000000003` and `100 * 2.3 = 229.99999999999997` and when this doesn't happen.