### PR TITLE
Bump jsonpointer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "generate-function": "^2.0.0",
     "generate-object-property": "^1.1.0",
-    "jsonpointer": "2.0.0",
+    "jsonpointer": "^4.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Braking change in 3.x:
- Drop node 0.6 and 0.8 support

Breaking changes in 4.x:
- When setting a `null` value, it now gets set as actual value. Previously we've deleted the property.
- When getting a non-existent value, we previously returned `null`.  We've now changed that to `undefined`.

I don't think that any of these changes affects this package.