### PR TITLE
Extend the supported data types using `types` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,23 @@ console.log(validate.errors) // [{field: 'data.y', message: 'is required'},
                              //  {field: 'data.x', message: 'is the wrong type'}]
 ```
 
+## Extend the supported data types using `types` option
+
+Add additional types (or extend the default types) by specifying the `types` option. For example if you need to add a validator function for type `file` (Swagger has a data type file), define file validator function as an `option` to validator.
+
+```js
+var schema = { type: 'file' }
+var validate = validator(schema, {
+    types: {
+        file: function (filename) {
+            return 'typeof '+filename+' === "string"';
+        }
+    }
+});
+validate('somefile.txt');
+
+```
+
 ## Performance
 
 is-my-json-valid uses code generation to turn your JSON schema into basic javascript code that is easily optimizeable by v8.

--- a/index.js
+++ b/index.js
@@ -114,6 +114,10 @@ var toType = function(node) {
 }
 
 var compile = function(schema, cache, root, reporter, opts) {
+  //Extend the types
+  if (opts && opts.types) {
+      types = xtend(types, opts.types);
+  }
   var fmts = opts ? xtend(formats, opts.formats) : formats
   var scope = {unique:unique, formats:fmts, isMultipleOf:isMultipleOf}
   var verbose = opts ? !!opts.verbose : false;

--- a/test/misc.js
+++ b/test/misc.js
@@ -469,3 +469,16 @@ tape('field shows item index in arrays', function(t) {
   t.strictEqual(validate.errors[0].field, 'data.1.1.foo', 'should output the field with specific index of failing item in the error')
   t.end()
 })
+
+tape('Extend types', function(t) {
+  var schema = { type: 'file' }
+  var validate = validator(schema, {
+      types: {
+          file: function (filename) {
+              return 'typeof '+filename+' === "string"';
+          }
+      }
+  });
+  t.ok(validate('somefile.text'), 'is file')
+  t.end()
+})


### PR DESCRIPTION
It would be really cool to provide an option to extend the default and supported `types`. 
This `types` option can be an easy fix/feature for anyone wanting to extend capabilities of the validator to - either define custom types for schema or trying to extend features of the existing validations.

One example of such a use case, would be `Swagger` `file` type. 