### PR TITLE
Add list of error messages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,33 @@ console.log(validate.errors) // [{field: 'data.y', message: 'is required'},
                              //  {field: 'data.x', message: 'is the wrong type'}]
 ```
 
+## Error messages
+
+Here is a list of possible `message` values for errors:
+
+* `is required`
+* `is the wrong type`
+* `has additional items`
+* `must be FORMAT format` (FORMAT is the `format` property from the schema)
+* `must be unique`
+* `must be an enum value`
+* `dependencies not set`
+* `has additional properties`
+* `referenced schema does not match`
+* `negative schema matches`
+* `pattern mismatch`
+* `no schemas match`
+* `no (or more than one) schemas match`
+* `has a remainder`
+* `has more properties than allowed`
+* `has less properties than allowed`
+* `has more items than allowed`
+* `has less items than allowed`
+* `has longer length than allowed`
+* `has less length than allowed`
+* `is less than minimum`
+* `is more than maximum`
+
 ## Performance
 
 is-my-json-valid uses code generation to turn your JSON schema into basic javascript code that is easily optimizeable by v8.


### PR DESCRIPTION
Hi,
I really like this library and appreciate all the work that has been put into it.
Currently I'm using it as part of an application that requires support for multiple languages. This means that using the message fields from errors directly isn't sufficient. What I need to do instead is look at what message is being generated and choose an appropriate string in the currently active language.
This means that I need to have a list of all possible error messages.
Crawling through the code to find them isn't difficult per se, however I think it would be more useful for people in similar situations to just look it up in the docs.
For a start, I've just added a list of all the messages in calls to the `error()` function, in the future it may be useful to add comments for what causes the error message (though I find it pretty obvious already)

Hopefully this is something that will be useful to the project. If not, at least I have the list for my own reference now. 😄 