### PR TITLE
Add test for nested selectors

### DIFF
--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -145,3 +145,23 @@ tape('schemaPath', function(t) {
 
   t.end()
 })
+
+tape('schemaPath - nested selectors', function(t) {
+  var schema = {
+    anyOf: [
+      { oneOf:[
+        { allOf: [
+          {
+            properties: {
+              nestedSelectors: {type: "integer"}
+            }
+          }
+        ]}
+      ]}
+    ]
+  }
+  var validate = validator(schema, { verbose: true, greedy: true } );
+  t.notOk(validate({nestedSelectors: "nope"}), 'should not crash on visit inside *Of');
+
+  t.end()
+})


### PR DESCRIPTION
This PR adds a test to cover #149, to go with the fix in #151.

The issues occurs when `visit()` is called from inside an `anyOf` or `oneOf` subschema, so we've got lots of tests around these keywords, but they're all terminal (`type`, `minimum` and `pattern`), and missed this case :'(

Thanks @shalevshalit and @LinusU (and everyone else who contributed) for fixing this so quickly!