### PR TITLE
fix: handle custom formats with null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ var compile = function(schema, cache, root, reporter, opts) {
     }
 
     if (node.format && fmts[node.format]) {
-      if (type !== 'string' && formats[node.format]) validate('if (%s) {', types.string(name))
+      if (type !== 'string' && fmts[node.format]) validate('if (%s) {', types.string(name))
       var n = gensym('format')
       scope[n] = fmts[node.format]
 
@@ -220,7 +220,7 @@ var compile = function(schema, cache, root, reporter, opts) {
       else validate('if (!%s.test(%s)) {', n, name)
       error('must be '+node.format+' format')
       validate('}')
-      if (type !== 'string' && formats[node.format]) validate('}')
+      if (type !== 'string' && fmts[node.format]) validate('}')
     }
 
     if (Array.isArray(node.required)) {

--- a/test/misc.js
+++ b/test/misc.js
@@ -237,6 +237,24 @@ tape('custom format', function(t) {
   t.end()
 })
 
+tape('custom format string or null', function (t) {
+  var validate = validator({
+    type: 'object',
+    properties: {
+      foo: {
+        type: ['string', 'null'],
+        format: 'as'
+      }
+    }
+  }, {formats: {as:/^a+$/}})
+
+  t.notOk(validate({foo:''}), 'not as')
+  t.notOk(validate({foo:'bar'}), 'not as')
+  t.ok(validate({foo:'a'}), 'as')
+  t.ok(validate({foo:null}), 'as')
+  t.end()
+})
+
 tape('custom format function', function(t) {
   var validate = validator({
     type: 'object',


### PR DESCRIPTION
If a custom formatted value (string) has null value and the type allows it, the validation should not fail.

Example that is failing on master and this PR is fixing

```js
{
    type: 'object',
    properties: {
      foo: {
        type: ['string', 'null'],
        format: 'as'
      }
    }
  }, {formats: {as:/^a+$/}
// object
{foo: null}
```

Seems this was due to `fmts` vs `formats` usage