### PR TITLE
Throw on invalid schema format

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ var isMultipleOf = function(name, multipleOf) {
 }
 
 var compile = function(schema, cache, root, reporter, opts) {
+  if (Buffer.isBuffer(schema) || schema === null || (typeof schema !== 'string' && typeof schema !== 'object')) {
+    throw new Error('First argument must be either a string a normal JavaScript object')
+  }
+
   var fmts = opts ? xtend(formats, opts.formats) : formats
   var scope = {unique:unique, formats:fmts, isMultipleOf:isMultipleOf}
   var verbose = opts ? !!opts.verbose : false;

--- a/test/misc.js
+++ b/test/misc.js
@@ -3,6 +3,28 @@ var cosmic = require('./fixtures/cosmic')
 var validator = require('../')
 var validatorRequire = require('../require')
 
+tape('invalid schemas', function(t) {
+  t.throws(function() {
+    validater(Buffer.from('foo'))
+  })
+  t.throws(function() {
+    validater(42)
+  })
+  t.throws(function() {
+    validater(null)
+  })
+  t.throws(function() {
+    validater(undefined)
+  })
+  t.throws(function() {
+    validater(Symbol())
+  })
+  t.throws(function() {
+    validater(NaN)
+  })
+  t.end()
+})
+
 tape('simple', function(t) {
   var schema = {
     required: true,


### PR DESCRIPTION
Prior to this change if your schema was in a Buffer, the validator would seem to work and pass all json as valid, but in reality it wasn't validating anything.