### PR TITLE
Add TypeScript support for enum types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,12 +16,16 @@ interface StringSchema {
 
 type LeafSchema = NullSchema | BooleanSchema | NumberSchema | StringSchema
 
-interface ArraySchema<T extends LeafSchema | ArraySchema<LeafSchema | ObjectSchema<ObjectProps, any>> | ObjectSchema<ObjectProps, any>> {
+interface EnumSchema<T> {
+  enum: T[]
+}
+
+interface ArraySchema<T extends LeafSchema | EnumSchema<any> | ArraySchema<LeafSchema | EnumSchema<any> | ObjectSchema<ObjectProps, any>> | ObjectSchema<ObjectProps, any>> {
   type: 'array'
   items: T
 }
 
-type ObjectProps = { [K in string]: LeafSchema | ArraySchema<LeafSchema | ArraySchema<LeafSchema | ObjectSchema<ObjectProps, any>> | ObjectSchema<ObjectProps, any>> | ObjectSchema<ObjectProps, any> }
+type ObjectProps = { [K in string]: LeafSchema | EnumSchema<any> | ArraySchema<LeafSchema | EnumSchema<any> | ArraySchema<LeafSchema | EnumSchema<any> | ObjectSchema<ObjectProps, any>> | ObjectSchema<ObjectProps, any>> | ObjectSchema<ObjectProps, any> }
 
 interface ObjectSchema<T extends ObjectProps, R extends keyof T> {
   additionalProperties?: boolean
@@ -37,16 +41,18 @@ declare type ExtractedSchemaObject<T, R> = {
 }
 
 declare type ExtractSchemaType<Type> = (
-    Type extends NullSchema ? null
-    : Type extends BooleanSchema ? boolean
-    : Type extends NumberSchema ? number
-    : Type extends StringSchema ? string
-    : Type extends ArraySchema<infer T> ? ExtractedSchemaArray<T>
-    : Type extends ObjectSchema<infer T, infer R> ? ExtractedSchemaObject<T, R>
-    : never
+  Type extends EnumSchema<infer T> ? T
+  : Type extends NullSchema ? null
+  : Type extends BooleanSchema ? boolean
+  : Type extends NumberSchema ? number
+  : Type extends StringSchema ? string
+  : Type extends ArraySchema<infer T> ? ExtractedSchemaArray<T>
+  : Type extends ObjectSchema<infer T, infer R> ? ExtractedSchemaObject<T, R>
+  : never
 )
 
 declare type GenericSchema = (
+  { enum: any[] } |
   { type: 'string' | 'number' | 'boolean' | 'null' } |
   { type: 'array', items: GenericSchema } |
   { type: 'object', properties: ObjectProps }

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -144,3 +144,40 @@ if (user2Validator(input)) {
     assertType<string>(input.items[0])
   }
 }
+
+const booleanValidator = createValidator({
+  enum: [true, false]
+})
+
+if (booleanValidator(input)) {
+  assertType<boolean>(input)
+}
+
+const specificValuesValidator = createValidator({
+  enum: [
+    true as true,
+    1000 as 1000,
+    'XX' as 'XX'
+  ]
+})
+
+if (specificValuesValidator(input)) {
+  assertType<true | 1000 | 'XX'>(input)
+}
+
+const metricValidator = createValidator({
+  type: 'object',
+  properties: {
+    name: { type: 'string', enum: ['page-view' as 'page-view'] },
+    page: { type: 'string', minLength: 0 }
+  },
+  required: [
+    'name',
+    'page'
+  ]
+})
+
+if (metricValidator(input)) {
+  assertType<'page-view'>(input.name)
+  assertType<string>(input.page)
+}


### PR DESCRIPTION
Currently, TypeScript will not narrow the literal types specified in the enum values. This means that if you specify your enum as `enum: ['a', 'b']` the type will come out as `string`, whereas an enum specified as `enum: ['a' as 'a', 'b' as 'b']` will be typed as `'a' | 'b'`.

This is unfortunate, but I don't have a solution to that at the moment. The good news is that fixing this is going to be a backward-compatible change, and this will still provide an upgrade from the previous behavior (e.g. previously a schema `{ enum: [...] }` would be typed as `never`).