### PR TITLE
Add toJSON to TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,38 +17,38 @@ interface StringSchema {
 }
 
 interface AnyEnumSchema extends EnumSchema<any> {}
-interface EnumSchema<T> {
-  enum: T[]
+interface EnumSchema<Enum> {
+  enum: Enum[]
 }
 
 interface AnyArraySchema extends ArraySchema<AnySchema> {}
-interface ArraySchema<T extends AnySchema> {
+interface ArraySchema<ItemSchema extends AnySchema> {
   type: 'array'
-  items: T
+  items: ItemSchema
 }
 
 interface AnyObjectSchema extends ObjectSchema<Record<string, AnySchema>, string> {}
-interface ObjectSchema<T extends Record<string, AnySchema>, R extends keyof T> {
+interface ObjectSchema<Properties extends Record<string, AnySchema>, Required extends keyof Properties> {
   additionalProperties?: boolean
   type: 'object'
-  properties: T
-  required: R[]
+  properties: Properties
+  required: Required[]
 }
 
-interface ExtractedSchemaArray<T> extends Array<ExtractSchemaType<T>> {}
+interface ExtractedSchemaArray<Schema> extends Array<ExtractSchemaType<Schema>> {}
 
-declare type ExtractedSchemaObject<T, R> = {
-  [K in keyof T]: (K extends R ? ExtractSchemaType<T[K]> : ExtractSchemaType<T[K]> | undefined)
+declare type ExtractedSchemaObject<Properties, Required> = {
+  [Key in keyof Properties]: (Key extends Required ? ExtractSchemaType<Properties[Key]> : ExtractSchemaType<Properties[Key]> | undefined)
 }
 
-declare type ExtractSchemaType<Type> = (
-  Type extends EnumSchema<infer T> ? T
-  : Type extends NullSchema ? null
-  : Type extends BooleanSchema ? boolean
-  : Type extends NumberSchema ? number
-  : Type extends StringSchema ? string
-  : Type extends ArraySchema<infer T> ? ExtractedSchemaArray<T>
-  : Type extends ObjectSchema<infer T, infer R> ? ExtractedSchemaObject<T, R>
+declare type ExtractSchemaType<Schema> = (
+    Schema extends EnumSchema<infer Enum> ? Enum
+  : Schema extends NullSchema ? null
+  : Schema extends BooleanSchema ? boolean
+  : Schema extends NumberSchema ? number
+  : Schema extends StringSchema ? string
+  : Schema extends ArraySchema<infer ItemSchema> ? ExtractedSchemaArray<ItemSchema>
+  : Schema extends ObjectSchema<infer Properties, infer Required> ? ExtractedSchemaObject<Properties, Required>
   : never
 )
 
@@ -72,11 +72,11 @@ declare interface Filter<Output> {
 }
 
 declare interface Factory {
-  <T extends Record<string, AnySchema>, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Validator<ObjectSchema<T, R>>
-  <T extends AnySchema> (schema: T, options?: any): Validator<T>
+  <Properties extends Record<string, AnySchema>, Required extends keyof Properties> (schema: ObjectSchema<Properties, Required>, options?: any): Validator<ObjectSchema<Properties, Required>>
+  <Schema extends AnySchema> (schema: Schema, options?: any): Validator<Schema>
 
-  createFilter<T extends Record<string, AnySchema>, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Filter<ExtractedSchemaObject<T, R>>
-  createFilter<T extends AnySchema> (schema: T, options?: any): Filter<ExtractSchemaType<T>>
+  createFilter<Properties extends Record<string, AnySchema>, Required extends keyof Properties> (schema: ObjectSchema<Properties, Required>, options?: any): Filter<ExtractedSchemaObject<Properties, Required>>
+  createFilter<Schema extends AnySchema> (schema: Schema, options?: any): Filter<ExtractSchemaType<Schema>>
 }
 
 declare const factory: Factory

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,17 +73,18 @@ declare interface Validator<Schema, Output = ExtractSchemaType<Schema>> {
   toJSON(): Schema
 }
 
-declare function createValidator<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Validator<ObjectSchema<T, R>>
-declare function createValidator<T extends GenericSchema> (schema: T, options?: any): Validator<T>
-
 declare interface Filter<Output> {
   (input: Output, options?: any): Output
 }
 
-declare function createFilter<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Filter<ExtractedSchemaObject<T, R>>
-declare function createFilter<T extends GenericSchema> (schema: T, options?: any): Filter<ExtractSchemaType<T>>
+declare interface Factory {
+  <T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Validator<ObjectSchema<T, R>>
+  <T extends GenericSchema> (schema: T, options?: any): Validator<T>
 
-declare type Factory = (typeof createValidator) & { filter: typeof createFilter }
+  createFilter<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Filter<ExtractedSchemaObject<T, R>>
+  createFilter<T extends GenericSchema> (schema: T, options?: any): Filter<ExtractSchemaType<T>>
+}
+
 declare const factory: Factory
 
 export = factory

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,11 +67,21 @@ declare namespace factory {
   }
 }
 
-declare function createValidator<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): ((input: unknown, options?: any) => input is { [K in keyof T]: (K extends R ? ExtractSchemaType<T[K]> : ExtractSchemaType<T[K]> | undefined) }) & { errors: factory.ValidationError[] }
-declare function createValidator<T extends GenericSchema> (schema: T, options?: any): ((input: unknown, options?: any) => input is ExtractSchemaType<T>) & { errors: factory.ValidationError[] }
+declare interface Validator<Schema, Output = ExtractSchemaType<Schema>> {
+  (input: unknown, options?: any): input is Output
+  errors: factory.ValidationError[]
+  toJSON(): Schema
+}
 
-declare function createFilter<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): ((input: { [K in keyof T]: (K extends R ? ExtractSchemaType<T[K]> : ExtractSchemaType<T[K]> | undefined) }, options?: any) => { [K in keyof T]: (K extends R ? ExtractSchemaType<T[K]> : ExtractSchemaType<T[K]> | undefined) })
-declare function createFilter<T extends GenericSchema> (schema: T, options?: any): ((input: ExtractSchemaType<T>, options?: any) => ExtractSchemaType<T>)
+declare function createValidator<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Validator<ObjectSchema<T, R>>
+declare function createValidator<T extends GenericSchema> (schema: T, options?: any): Validator<T>
+
+declare interface Filter<Output> {
+  (input: Output, options?: any): Output
+}
+
+declare function createFilter<T extends ObjectProps, R extends keyof T> (schema: ObjectSchema<T, R>, options?: any): Filter<ExtractedSchemaObject<T, R>>
+declare function createFilter<T extends GenericSchema> (schema: T, options?: any): Filter<ExtractSchemaType<T>>
 
 declare type Factory = (typeof createValidator) & { filter: typeof createFilter }
 declare const factory: Factory

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,20 +35,20 @@ interface ObjectSchema<Properties extends Record<string, AnySchema>, Required ex
   required: Required[]
 }
 
-interface ExtractedSchemaArray<Schema> extends Array<ExtractSchemaType<Schema>> {}
+interface ArrayFromSchema<Schema> extends Array<TypeFromSchema<Schema>> {}
 
-declare type ExtractedSchemaObject<Properties, Required> = {
-  [Key in keyof Properties]: (Key extends Required ? ExtractSchemaType<Properties[Key]> : ExtractSchemaType<Properties[Key]> | undefined)
+declare type ObjectFromSchema<Properties, Required> = {
+  [Key in keyof Properties]: (Key extends Required ? TypeFromSchema<Properties[Key]> : TypeFromSchema<Properties[Key]> | undefined)
 }
 
-declare type ExtractSchemaType<Schema> = (
+declare type TypeFromSchema<Schema> = (
     Schema extends EnumSchema<infer Enum> ? Enum
   : Schema extends NullSchema ? null
   : Schema extends BooleanSchema ? boolean
   : Schema extends NumberSchema ? number
   : Schema extends StringSchema ? string
-  : Schema extends ArraySchema<infer ItemSchema> ? ExtractedSchemaArray<ItemSchema>
-  : Schema extends ObjectSchema<infer Properties, infer Required> ? ExtractedSchemaObject<Properties, Required>
+  : Schema extends ArraySchema<infer ItemSchema> ? ArrayFromSchema<ItemSchema>
+  : Schema extends ObjectSchema<infer Properties, infer Required> ? ObjectFromSchema<Properties, Required>
   : never
 )
 
@@ -61,7 +61,7 @@ declare namespace factory {
   }
 }
 
-declare interface Validator<Schema, Output = ExtractSchemaType<Schema>> {
+declare interface Validator<Schema, Output = TypeFromSchema<Schema>> {
   (input: unknown, options?: any): input is Output
   errors: factory.ValidationError[]
   toJSON(): Schema
@@ -75,8 +75,8 @@ declare interface Factory {
   <Properties extends Record<string, AnySchema>, Required extends keyof Properties> (schema: ObjectSchema<Properties, Required>, options?: any): Validator<ObjectSchema<Properties, Required>>
   <Schema extends AnySchema> (schema: Schema, options?: any): Validator<Schema>
 
-  createFilter<Properties extends Record<string, AnySchema>, Required extends keyof Properties> (schema: ObjectSchema<Properties, Required>, options?: any): Filter<ExtractedSchemaObject<Properties, Required>>
-  createFilter<Schema extends AnySchema> (schema: Schema, options?: any): Filter<ExtractSchemaType<Schema>>
+  createFilter<Properties extends Record<string, AnySchema>, Required extends keyof Properties> (schema: ObjectSchema<Properties, Required>, options?: any): Filter<ObjectFromSchema<Properties, Required>>
+  createFilter<Schema extends AnySchema> (schema: Schema, options?: any): Filter<TypeFromSchema<Schema>>
 }
 
 declare const factory: Factory

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -9,6 +9,7 @@ function assertType<T>(value: T): void {}
 const input = null as unknown
 
 const nullValidator = createValidator({ type: 'null' })
+assertType<{ type: 'null' }>(nullValidator.toJSON())
 
 if (nullValidator(input)) {
   assertType<null>(input)
@@ -22,12 +23,14 @@ assertType<string>(nullValidator.errors[0].type)
 assertType<unknown>(nullValidator.errors[0].value)
 
 const numberValidator = createValidator({ type: 'number' })
+assertType<{ type: 'number' }>(numberValidator.toJSON())
 
 if (numberValidator(input)) {
   assertType<number>(input)
 }
 
 const stringValidator = createValidator({ type: 'string' })
+assertType<{ type: 'string' }>(stringValidator.toJSON())
 
 if (stringValidator(input)) {
   assertType<string>(input)


### PR DESCRIPTION
Adds the `toJSON` function to the TypeScript typings which just returns the type of the schema.

Also refactors the typings to have an explicit type for a `Validator` and `Filter`, just made typing things out a bit easier.