### PR TITLE
Fix a ReDoS in 'style' format

### DIFF
--- a/formats.js
+++ b/formats.js
@@ -28,7 +28,7 @@ exports['hostname'] = function (input) {
 }
 exports['alpha'] = /^[a-zA-Z]+$/
 exports['alphanumeric'] = /^[a-zA-Z0-9]+$/
-exports['style'] = /\s*(.+?):\s*([^;]+);?/g
+exports['style'] = /.:\s*[^;]/g
 exports['phone'] = function (input) {
   if (!(rePhoneFirstPass.test(input))) return false
   if (rePhoneDoubleSpace.test(input)) return false


### PR DESCRIPTION
Filing a public PR as requested.

As there are no `^` or `$` anchors in the regex, this should be equivalent.
Patch deliberately does not change the behavior.

If the intent was to include `^` and `$` and those were missed due to an unrelated mistake, I can probably propose another safe regex for that (but that would change the behavior).

Please recheck that this regex is correct.