### PR TITLE
undefined array items bypasses validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,6 +383,9 @@ var compile = function(schema, cache, root, reporter, opts) {
 
       var i = genloop()
       validate('for (var %s = 0; %s < %s.length; %s++) {', i, i, name, i)
+      // Since undefined is not a valid JSON value, we coerce all undefined items in the array to null
+      // We do it like this to not have to mutate the original data
+      validate('if (%s === undefined) %s = %s.map(function (item) { return item === undefined ? null : item })', name+'['+i+']', name, name)
       visit(name+'['+i+']', node.items, reporter, filter, schemaPath.concat('items'))
       validate('}')
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -28,6 +28,19 @@ tape('data is undefined', function (t) {
   t.end()
 })
 
+tape('array item is undefined', function (t) {
+  var validate = validator({type: 'array', minItems: 1, items: { type: 'string' } })
+
+  t.ok(validate(['a']))
+  t.notOk(validate([null]), 'null should not be consider a string array item')
+  t.notOk(validate([{}]), 'object should not be consider a string array item')
+
+  var arr = [undefined]
+  t.notOk(validate(arr), 'undefined should not be consider a string array item')
+  t.ok(arr[0] === undefined, 'array should not be mutated')
+  t.end()
+})
+
 tape('advanced', function(t) {
   var validate = validator(cosmic.schema)
 


### PR DESCRIPTION
This is the same scenario as 
https://github.com/mafintosh/is-my-json-valid/issues/116 / https://github.com/mafintosh/is-my-json-valid/commit/9721fe31e362d5be5da9c7a0047c8e5c888aee88

but for array items