### PR TITLE
Upgrade jsonpointer to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-function": "^2.0.0",
     "generate-object-property": "^1.1.0",
     "is-my-ip-valid": "^1.0.0",
-    "jsonpointer": "^4.0.0",
+    "jsonpointer": "^5.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses [CVE-2021-23807](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23807) through upgrading `jsonpointer` to > `v5.0.0`

Fixes #189 