### PR TITLE
add test for false negative on multipleOf

### DIFF
--- a/test/json-schema-draft4/multipleOf.json
+++ b/test/json-schema-draft4/multipleOf.json
@@ -92,5 +92,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by big number",
+        "schema": {"multipleOf": 0.01},
+        "tests": [
+            {
+                "description": "1658529657949 is multiple of 0.01",
+                "data": 1658529657949,
+                "valid": true
+            },
+            {
+                "description": "1658529657949.05 is multiple of 0.01",
+                "data": 1658529657949.05,
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Using multipleOf `0.01` fails to validate a big number that does not contain a decimal part.


`1658529657949.05` is valid, as it should be.
`165` is valid, as it should be.
`1658529657949` is not valid, **but should be valid**.


**NOTICE**: This PR adds a failing test, but it does not contain a proper solution. Do not merge this without a fix.