### PR TITLE
Fixed PR #192 (multipleOf decimal with big integer value)

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,9 +93,9 @@ var unique = function(array, len) {
 
 var isMultipleOf = function(name, multipleOf) {
   var res;
-  var factor = ((multipleOf | 0) !== multipleOf) ? Math.pow(10, multipleOf.toString().split('.').pop().length) : 1
+  var factor = Number.isInteger(multipleOf) ? 1 :  Math.pow(10,  multipleOf.toString().split('.').pop().length)
   if (factor > 1) {
-    var factorName = ((name | 0) !== name) ? Math.pow(10, name.toString().split('.').pop().length) : 1
+    var factorName = Number.isInteger(name) ? 1 : Math.pow(10, name.toString().split('.').pop().length)
     if (factorName > factor) res = true
     else res = Math.round(factor * name) % (factor * multipleOf)
   }

--- a/test/json-schema-draft4/multipleOf.json
+++ b/test/json-schema-draft4/multipleOf.json
@@ -92,5 +92,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by big number",
+        "schema": {"multipleOf": 0.01},
+        "tests": [
+            {
+                "description": "1658529657949 is multiple of 0.01",
+                "data": 1658529657949,
+                "valid": true
+            },
+            {
+                "description": "1658529657949.05 is multiple of 0.01",
+                "data": 1658529657949.05,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/test/json-schema-draft4/multipleOf.json
+++ b/test/json-schema-draft4/multipleOf.json
@@ -106,6 +106,11 @@
                 "description": "1658529657949.05 is multiple of 0.01",
                 "data": 1658529657949.05,
                 "valid": true
+            },
+            {
+                "description": "1658529657949.055 is not multiple of 0.01",
+                "data": 1658529657949.055,
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
https://github.com/mafintosh/is-my-json-valid/pull/192

The issue seemed to be that `number | 0 !== number` to detect integers doesn't work for big numbers. I replaced it with the `Number.isInteger` function, which seems to handle all test cases quite well

Also inverted the ternary operator to avoid the negation. I also suggest replacing `multipleOf.toString().split('.').pop().length` with a named function

`const getDecimalPart = (num) =>  num.toString().split(".").pop();`
`const getNumberOfDecimals = (num) => getDecimalPart(num).length;`

`var factor = Number.isInteger(multipleOf) ? 1 :  Math.pow(10,  getNumberOfDecimals(multipleOf))`
